### PR TITLE
Add getter to root item of qml overlay.

### DIFF
--- a/hector_rviz_overlay/include/hector_rviz_overlay/ui/qml_overlay.h
+++ b/hector_rviz_overlay/include/hector_rviz_overlay/ui/qml_overlay.h
@@ -142,6 +142,10 @@ public:
 
   QQmlEngine *engine();
 
+  const QQuickItem *rootItem() const;
+
+  QQuickItem *rootItem();
+
 signals:
 
   void statusChanged( hector_rviz_overlay::QmlOverlay::Status status );

--- a/hector_rviz_overlay/src/ui/qml_overlay.cpp
+++ b/hector_rviz_overlay/src/ui/qml_overlay.cpp
@@ -476,4 +476,14 @@ QQmlEngine *QmlOverlay::engine()
 {
   return engine_;
 }
+
+const QQuickItem *QmlOverlay::rootItem() const
+{
+  return root_item_;
+}
+
+QQuickItem *QmlOverlay::rootItem()
+{
+  return root_item_;
+}
 }


### PR DESCRIPTION
Add getter to root item of a qml overlay. This enables us to better interact with QML-based objects from C++ code, e.g. connecting signal and slots.